### PR TITLE
Rename DeliverEventHandlerTest::testInvokeCallbackNotExists()

### DIFF
--- a/tests/Unit/MessageHandler/DeliverEventHandlerTest.php
+++ b/tests/Unit/MessageHandler/DeliverEventHandlerTest.php
@@ -16,7 +16,7 @@ class DeliverEventHandlerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function testInvokeCallbackNotExists(): void
+    public function testInvokeWorkerEventDoesNotExist(): void
     {
         $workerEventId = 0;
         $message = new DeliverEventMessage($workerEventId);


### PR DESCRIPTION
Fixes #374