### PR TITLE
Rename 'callback_state' in job controller status output

### DIFF
--- a/src/Controller/JobController.php
+++ b/src/Controller/JobController.php
@@ -118,7 +118,7 @@ class JobController
                 'sources' => $sourceRepository->findAllPaths(),
                 'compilation_state' => (string) $compilationState,
                 'execution_state' => (string) $executionState,
-                'callback_state' => (string) $workerEventState,
+                'event_delivery_state' => (string) $workerEventState,
                 'tests' => $testSerializer->serializeCollection($tests),
             ]
         );

--- a/tests/Functional/Controller/JobControllerTest.php
+++ b/tests/Functional/Controller/JobControllerTest.php
@@ -499,7 +499,7 @@ class JobControllerTest extends AbstractBaseFunctionalTest
                     'sources' => [],
                     'compilation_state' => 'awaiting',
                     'execution_state' => 'awaiting',
-                    'callback_state' => 'awaiting',
+                    'event_delivery_state' => 'awaiting',
                     'tests' => [],
                 ],
             ],
@@ -526,7 +526,7 @@ class JobControllerTest extends AbstractBaseFunctionalTest
                     ],
                     'compilation_state' => 'running',
                     'execution_state' => 'awaiting',
-                    'callback_state' => 'awaiting',
+                    'event_delivery_state' => 'awaiting',
                     'tests' => [],
                 ],
             ],
@@ -562,7 +562,7 @@ class JobControllerTest extends AbstractBaseFunctionalTest
                     ],
                     'compilation_state' => 'running',
                     'execution_state' => 'awaiting',
-                    'callback_state' => 'awaiting',
+                    'event_delivery_state' => 'awaiting',
                     'tests' => [
                         [
                             'configuration' => [

--- a/tests/Image/AppTest.php
+++ b/tests/Image/AppTest.php
@@ -127,7 +127,7 @@ class AppTest extends TestCase
             ],
             'compilation_state' => 'complete',
             'execution_state' => 'complete',
-            'callback_state' => 'complete',
+            'event_delivery_state' => 'complete',
             'tests' => [
                 [
                     'configuration' => [
@@ -196,6 +196,6 @@ class AppTest extends TestCase
 
         return CompilationState::STATE_COMPLETE === $jobStatus['compilation_state']
             && ExecutionState::STATE_COMPLETE === $jobStatus['execution_state']
-            && WorkerEventState::STATE_COMPLETE === $jobStatus['callback_state'];
+            && WorkerEventState::STATE_COMPLETE === $jobStatus['event_delivery_state'];
     }
 }

--- a/tests/Integration/EndToEnd/CreateCompileExecuteTest.php
+++ b/tests/Integration/EndToEnd/CreateCompileExecuteTest.php
@@ -118,7 +118,7 @@ class CreateCompileExecuteTest extends AbstractBaseIntegrationTest
         self::assertSame($jobMaximumDurationInSeconds, $statusData['maximum_duration_in_seconds']);
         self::assertSame($expectedCompilationEndState, $statusData['compilation_state']);
         self::assertSame($expectedExecutionEndState, $statusData['execution_state']);
-        self::assertSame(WorkerEventState::STATE_COMPLETE, $statusData['callback_state']);
+        self::assertSame(WorkerEventState::STATE_COMPLETE, $statusData['event_delivery_state']);
         self::assertSame($sourcePaths, $statusData['sources']);
 
         $testDataCollection = $statusData['tests'];

--- a/tests/Services/Asserter/SerializedJobAsserter.php
+++ b/tests/Services/Asserter/SerializedJobAsserter.php
@@ -31,7 +31,7 @@ class SerializedJobAsserter
         TestCase::assertSame($expectedJob['sources'], $job['sources']);
         TestCase::assertSame($expectedJob['compilation_state'], $job['compilation_state']);
         TestCase::assertSame($expectedJob['execution_state'], $job['execution_state']);
-        TestCase::assertSame($expectedJob['callback_state'], $job['callback_state']);
+        TestCase::assertSame($expectedJob['event_delivery_state'], $job['event_delivery_state']);
 
         TestCase::assertIsArray($job['tests']);
         TestCase::assertIsArray($expectedJob['tests']);


### PR DESCRIPTION
Fixes #378