### PR TITLE
Use no spacing for composite types, use single spacing for multiple catch types

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,7 +16,8 @@ return (new PhpCsFixer\Config())
         'php_unit_internal_class' => false,
         'php_unit_test_class_requires_covers' => false,
         'types_spaces' => [
-            'space' => 'single',
+            'space' => 'none',
+            'space_multiple_catch' => 'single',
         ],
         'blank_line_before_statement' => [
             'statements' => [

--- a/src/Services/Compiler.php
+++ b/src/Services/Compiler.php
@@ -22,7 +22,7 @@ class Compiler
     ) {
     }
 
-    public function compile(string $source): ErrorOutputInterface | SuiteManifest
+    public function compile(string $source): ErrorOutputInterface|SuiteManifest
     {
         $output = '';
         $exitCode = null;


### PR DESCRIPTION
Fixes #497