### PR TITLE
EventInterface::getRelatedReferenceValues() must return collection of non-empty string

### DIFF
--- a/src/Event/EventInterface.php
+++ b/src/Event/EventInterface.php
@@ -21,7 +21,7 @@ interface EventInterface
     public function getType(): WorkerEventType;
 
     /**
-     * @return string[]
+     * @return non-empty-string[]
      */
     public function getRelatedReferenceValues(): array;
 }


### PR DESCRIPTION
Fixes #511