### PR TITLE
SourcePathFinder::findNextNonCompiledPath() returns a non-empty string

### DIFF
--- a/src/Services/SourcePathFinder.php
+++ b/src/Services/SourcePathFinder.php
@@ -28,6 +28,9 @@ class SourcePathFinder
         return $this->removeCompilerSourceDirectoryPrefixFromPaths($sources);
     }
 
+    /**
+     * @return null|non-empty-string
+     */
     public function findNextNonCompiledPath(): ?string
     {
         $sourcePaths = $this->sourceRepository->findAllPaths(Source::TYPE_TEST);


### PR DESCRIPTION
Fixes #519