### PR TITLE
CompileSourceMessage::path is a non-empty string

### DIFF
--- a/src/Message/CompileSourceMessage.php
+++ b/src/Message/CompileSourceMessage.php
@@ -6,12 +6,10 @@ namespace App\Message;
 
 class CompileSourceMessage
 {
-    public function __construct(private string $path)
+    /**
+     * @param non-empty-string $path
+     */
+    public function __construct(public readonly string $path)
     {
-    }
-
-    public function getPath(): string
-    {
-        return $this->path;
     }
 }

--- a/src/MessageHandler/CompileSourceHandler.php
+++ b/src/MessageHandler/CompileSourceHandler.php
@@ -30,7 +30,7 @@ class CompileSourceHandler implements MessageHandlerInterface
             return;
         }
 
-        $sourcePath = $message->getPath();
+        $sourcePath = $message->path;
 
         $this->eventDispatcher->dispatch(new SourceCompilationStartedEvent($sourcePath));
 

--- a/tests/Functional/MessageHandler/CompileSourceHandlerTest.php
+++ b/tests/Functional/MessageHandler/CompileSourceHandlerTest.php
@@ -116,7 +116,7 @@ class CompileSourceHandlerTest extends AbstractBaseFunctionalTest
 
         $compiler = (new MockCompiler())
             ->withCompileCall(
-                $compileSourceMessage->getPath(),
+                $compileSourceMessage->path,
                 $suiteManifest
             )
             ->getMock()
@@ -192,7 +192,7 @@ class CompileSourceHandlerTest extends AbstractBaseFunctionalTest
 
         $compiler = (new MockCompiler())
             ->withCompileCall(
-                $compileSourceMessage->getPath(),
+                $compileSourceMessage->path,
                 $errorOutput
             )
             ->getMock()

--- a/tests/Unit/Message/CompileSourceMessageTest.php
+++ b/tests/Unit/Message/CompileSourceMessageTest.php
@@ -22,6 +22,6 @@ class CompileSourceMessageTest extends TestCase
 
     public function testGetPath(): void
     {
-        self::assertSame(self::PATH, $this->message->getPath());
+        self::assertSame(self::PATH, $this->message->path);
     }
 }


### PR DESCRIPTION
Fixes #518