### PR TITLE
ResourceReference::toArray() returns non-empty strings

### DIFF
--- a/src/Entity/ResourceReference.php
+++ b/src/Entity/ResourceReference.php
@@ -38,7 +38,7 @@ class ResourceReference
     }
 
     /**
-     * @return array{label: string, reference: string}
+     * @return array{label: non-empty-string, reference: non-empty-string}
      */
     public function toArray(): array
     {

--- a/src/Entity/WorkerEvent.php
+++ b/src/Entity/WorkerEvent.php
@@ -101,7 +101,7 @@ class WorkerEvent
      *     label: non-empty-string,
      *     reference: string,
      *     payload: array<mixed>,
-     *     related_references?: array<int, array{label: string, reference: string}>
+     *     related_references?: array<int, array{label: non-empty-string, reference: non-empty-string}>
      * }
      */
     public function toArray(): array

--- a/src/Model/ResourceReferenceCollection.php
+++ b/src/Model/ResourceReferenceCollection.php
@@ -30,7 +30,7 @@ class ResourceReferenceCollection implements \IteratorAggregate
     }
 
     /**
-     * @return array<int, array{label: string, reference: string}>
+     * @return array<int, array{label: non-empty-string, reference: non-empty-string}>
      */
     public function toArray(): array
     {


### PR DESCRIPTION
Fixes #836